### PR TITLE
Add scroll-to-top button across pages

### DIFF
--- a/flash/index.html
+++ b/flash/index.html
@@ -1227,6 +1227,7 @@
             }, { passive: false });
         })();
     </script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>

--- a/heart-moving/index.html
+++ b/heart-moving/index.html
@@ -503,6 +503,7 @@
     <!-- Legacy inline script removed: functionality now provided by player.js -->
     <script src="../player.js"></script>
     <script>initLyricPlayer({ title: 'ハート ムーヴィング', video: '#bg-video', lyrics: '#lyrics-body' });</script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -214,6 +214,7 @@
             });
         }).catch(err => console.error(err));
     </script>
+    <script src="scroll-top.js"></script>
 </body>
 
 </html>

--- a/kirari/index.html
+++ b/kirari/index.html
@@ -635,6 +635,7 @@
     <!-- Legacy inline script removed: functionality now provided by player.js -->
     <script src="../player.js"></script>
     <script>initLyricPlayer({ title: 'セーラースターソング', video: '#bg-video', lyrics: '#lyrics-body' });</script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>

--- a/moonlight-densetsu/index.html
+++ b/moonlight-densetsu/index.html
@@ -666,6 +666,7 @@
     <!-- Legacy inline script removed; unified player.js handles controls, highlighting, tooltips, furigana -->
     <script src="../player.js"></script>
     <script>initLyricPlayer({ title: 'ムーンライト伝説', video: '#bg-video', lyrics: '#lyrics-body' });</script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>

--- a/otome-no-policy/index.html
+++ b/otome-no-policy/index.html
@@ -971,6 +971,7 @@
     </script>
     <script src="../player.js"></script>
     <script>initLyricPlayer({ title: '乙女のポリシー', video: '#bg-video', lyrics: '#lyrics-body' });</script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>

--- a/princess-moon/index.html
+++ b/princess-moon/index.html
@@ -781,6 +781,7 @@
     <!-- Legacy inline script removed; functionality provided by player.js -->
     <script src="../player.js"></script>
     <script>initLyricPlayer({ title: 'プリンセス ムーン', video: '#bg-video', lyrics: '#lyrics-body' });</script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>

--- a/scroll-top.js
+++ b/scroll-top.js
@@ -1,0 +1,42 @@
+(function(){
+  const scrollTarget = document.querySelector('.container');
+  const btn = document.createElement('button');
+  btn.textContent = '\u2191';
+  btn.setAttribute('aria-label', 'Scroll to top');
+  Object.assign(btn.style, {
+    position: 'fixed',
+    right: '20px',
+    bottom: '20px',
+    width: '40px',
+    height: '40px',
+    border: 'none',
+    borderRadius: '50%',
+    background: '#4a5568',
+    color: '#fff',
+    display: 'none',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    boxShadow: '0 2px 6px rgba(0,0,0,0.3)',
+    zIndex: '1000'
+  });
+  document.body.appendChild(btn);
+
+  const scroller = scrollTarget || window;
+  function currentScrollTop(){
+    return scrollTarget ? scrollTarget.scrollTop : (window.scrollY || document.documentElement.scrollTop);
+  }
+  function toggle(){
+    btn.style.display = currentScrollTop() > 100 ? 'flex' : 'none';
+  }
+  scroller.addEventListener('scroll', toggle);
+  toggle();
+
+  btn.addEventListener('click', () => {
+    if (scrollTarget) {
+      scrollTarget.scrollTo({ top: 0, behavior: 'smooth' });
+    } else {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+  });
+})();

--- a/tuxedo-mirage/index.html
+++ b/tuxedo-mirage/index.html
@@ -382,6 +382,7 @@
     </div>
     <script src="../player.js"></script>
     <script>initLyricPlayer({ title: 'タキシード・ミラージュ', video: '#bg-video', lyrics: '#lyrics-body' });</script>
+    <script src="../scroll-top.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- Create a reusable `scroll-top.js` script that injects a floating button to scroll back to top
- Include the script on the home page and all lyric pages

## Testing
- `node --check scroll-top.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b266d000a083309e3e4bc0c8e614ef