### PR TITLE
Add flashcard and back buttons

### DIFF
--- a/flash/index.html
+++ b/flash/index.html
@@ -561,7 +561,7 @@
         <div class="app-title" aria-hidden="true">単語カード</div>
         <div class="left">
             <div class="top-buttons">
-                <button id="btnExit" class="btn" aria-label="Exit">✕</button>
+                <button id="btnExit" class="btn" aria-label="Back">←</button>
                 <button id="btnRestart" class="btn" aria-label="Restart">↺</button>
                 <button id="btnShuffle" class="btn" aria-label="Shuffle">🔀</button>
                 <button id="btnReverse" class="btn" aria-label="Reverse Front/Back">⇄</button>

--- a/index.html
+++ b/index.html
@@ -117,11 +117,28 @@
         .song-link:hover {
             background: #ffe066;
         }
+
+        .flash-btn {
+            display: inline-block;
+            margin-bottom: 20px;
+            padding: 8px 18px;
+            background: #f6e05e;
+            color: #1a202c;
+            border-radius: 6px;
+            font-weight: 600;
+            text-decoration: none;
+            transition: background 0.15s;
+        }
+
+        .flash-btn:hover {
+            background: #ffe066;
+        }
     </style>
 </head>
 
 <body>
     <h1>ムーン</h1>
+    <a class="flash-btn" href="flash/index.html">Flashcards</a>
     <div class="song-list" id="song-list"></div>
     <script>
         // Fetch song folders from JSON list


### PR DESCRIPTION
## Summary
- add Flashcards button to home page
- switch flashcard exit control to back arrow

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b347030930833087108efdef00aa0a

## Summary by Sourcery

Add navigation improvements by introducing a Flashcards button on the home screen and changing the flashcard exit control to a back arrow.

New Features:
- Add Flashcards button to the home page

Enhancements:
- Replace flashcard exit button icon and aria-label with a back arrow