### PR TITLE
Make song page headers sticky

### DIFF
--- a/heart-moving/index.html
+++ b/heart-moving/index.html
@@ -16,9 +16,10 @@
     <div class="video-overlay"></div>
 
     <div class="container">
-        <h1>ハート ムーヴィング</h1>
-
-        <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        <div class="sticky-header">
+            <h1>ハート ムーヴィング</h1>
+            <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        </div>
         <div id="lyrics-body" class="lyrics-grid">
             <div class="lyric-row" data-start-time="2" data-end-time="8">
                 <p class="japanese-line">

--- a/kirari/index.html
+++ b/kirari/index.html
@@ -16,9 +16,10 @@
     <div class="video-overlay"></div>
 
     <div class="container">
-        <h1>セーラースターソング</h1>
-
-        <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        <div class="sticky-header">
+            <h1>セーラースターソング</h1>
+            <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        </div>
         <div id="lyrics-body" class="lyrics-grid">
             <div class="lyric-row" data-start-time="1" data-end-time="5">
                 <p class="japanese-line">

--- a/moonlight-densetsu/index.html
+++ b/moonlight-densetsu/index.html
@@ -16,9 +16,10 @@
     <div class="video-overlay"></div>
 
     <div class="container">
-        <h1>ムーンライト<ruby>伝説<rt>でんせつ</rt></ruby></h1>
-
-        <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        <div class="sticky-header">
+            <h1>ムーンライト<ruby>伝説<rt>でんせつ</rt></ruby></h1>
+            <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        </div>
         <div id="lyrics-body" class="lyrics-grid">
             <div class="lyric-row" data-start-time="27.740" data-end-time="31.480">
                 <p class="japanese-line">

--- a/otome-no-policy/index.html
+++ b/otome-no-policy/index.html
@@ -15,8 +15,10 @@
     </div>
     <div class="video-overlay"></div>
     <div class="container">
-        <h1>乙女のポリシー</h1>
-        <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        <div class="sticky-header">
+            <h1>乙女のポリシー</h1>
+            <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        </div>
         <div id="lyrics-body" class="lyrics-grid">
             <div class="lyric-row" data-start-time="12.080" data-end-time="18.320">
                 <p class="japanese-line">

--- a/tuxedo-mirage/index.html
+++ b/tuxedo-mirage/index.html
@@ -17,8 +17,8 @@
     <div class="container">
         <div class="sticky-header">
             <h1>タキシード・ミラージュ</h1>
-            <div class="controls main-controls"><!-- buttons injected by player.js --></div>
         </div>
+        <div class="controls main-controls"><!-- buttons injected by player.js --></div>
         <div id="lyrics-body" class="lyrics-grid">
             <div class="lyric-row" data-start-time="10.000" data-end-time="19.000">
                 <p class="japanese-line">

--- a/tuxedo-mirage/index.html
+++ b/tuxedo-mirage/index.html
@@ -15,7 +15,10 @@
     </div>
     <div class="video-overlay"></div>
     <div class="container">
-        <h1>タキシード・ミラージュ</h1>
+        <div class="sticky-header">
+            <h1>タキシード・ミラージュ</h1>
+            <div class="controls main-controls"><!-- buttons injected by player.js --></div>
+        </div>
         <div id="lyrics-body" class="lyrics-grid">
             <div class="lyric-row" data-start-time="10.000" data-end-time="19.000">
                 <p class="japanese-line">


### PR DESCRIPTION
## Summary
- Wrap each song page title and control container in a `.sticky-header` so they remain visible while scrolling.

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b3494538108330a7622b8a6d08c341

## Summary by Sourcery

Enhancements:
- Wrap each song page’s title and control buttons in a .sticky-header container to keep them visible while scrolling