### PR TITLE
style: center flash overlay

### DIFF
--- a/song.css
+++ b/song.css
@@ -146,6 +146,25 @@ body {
     fill: currentColor;
 }
 
+.flash-overlay {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 1000;
+}
+
+.flash-iframe {
+    width: 75vw;
+    height: 75vh;
+    border: none;
+    border-radius: 12px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+    background: #fff;
+}
+
 h1 {
     text-align: center;
     color: #ffffff;


### PR DESCRIPTION
## Summary
- center flashcard overlay and give it a backdrop
- size flashcard iframe to 75% of viewport with subtle styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b34c760a0c833081547208925f6fe8

## Summary by Sourcery

Add CSS styles to center the flashcard overlay with a backdrop and style the flashcard iframe at 75% viewport size with subtle visual enhancements.

Enhancements:
- Add .flash-overlay class to position the flashcard overlay fixed, center it, and apply a semi-transparent backdrop
- Add .flash-iframe class to size the iframe to 75vw by 75vh and apply border-radius, box-shadow, and background styles